### PR TITLE
FF-1032: refactor(security): replace supabase jwt flag with hmac fall…

### DIFF
--- a/src/main/kotlin/org/incept5/platform/core/security/DualJwtValidator.kt
+++ b/src/main/kotlin/org/incept5/platform/core/security/DualJwtValidator.kt
@@ -49,7 +49,6 @@ class DualJwtValidator @Inject constructor(
             val publicKey = derivePublicKeyFromPrivate(rsaPrivateKey)
             return Algorithm.RSA256(publicKey, null)
         } else {
-            log.info("HMAC Fallback Enabled: ${hmacFallbackEnabled}")
             if (hmacFallbackEnabled) {
                 return Algorithm.HMAC256(Base64.getDecoder().decode(jwtSecret))
             }
@@ -80,8 +79,6 @@ class DualJwtValidator @Inject constructor(
         try {
             val decoded = JWT.decode(token)
             val issuer = decoded.issuer
-
-            log.info("Token issuer: $issuer")
 
             return when {
                 issuer == "$baseApiUrl$supabaseAuthPath" -> TokenSource.SUPABASE

--- a/src/main/kotlin/org/incept5/platform/core/security/DualJwtValidator.kt
+++ b/src/main/kotlin/org/incept5/platform/core/security/DualJwtValidator.kt
@@ -25,8 +25,8 @@ class UnknownTokenException(message: String, cause: Throwable? = null) :
 class DualJwtValidator @Inject constructor(
     @ConfigProperty(name = "supabase.jwt.secret")
     private val jwtSecret: String,
-    @ConfigProperty(name = "supabase.jwt.enabled", defaultValue = "false")
-    private val supabaseJwtEnabled: Boolean = true,
+    @ConfigProperty(name = "rsa-jwt.hmac-fallback.enabled", defaultValue = "false")
+    private val hmacFallbackEnabled: Boolean = false,
     @ConfigProperty(name = "api.base.url")
     private val baseApiUrl: String,
     @ConfigProperty(name = "auth.supabase.path", defaultValue = "/auth/v1")
@@ -41,9 +41,6 @@ class DualJwtValidator @Inject constructor(
     private val log = Logger.getLogger(DualJwtValidator::class.java)
 
     private fun requireSupabaseAlgorithm(): Algorithm {
-        if (!supabaseJwtEnabled) {
-            throw UnknownTokenException("HS256 validation disabled by configuration")
-        }
         return Algorithm.HMAC256(Base64.getDecoder().decode(jwtSecret))
     }
 
@@ -51,9 +48,11 @@ class DualJwtValidator @Inject constructor(
         if (rsaEnabled && rsaPrivateKey.isNotBlank()) {
             val publicKey = derivePublicKeyFromPrivate(rsaPrivateKey)
             return Algorithm.RSA256(publicKey, null)
-        }
-        if (supabaseJwtEnabled) {
-            return Algorithm.HMAC256(Base64.getDecoder().decode(jwtSecret))
+        } else {
+            log.info("HMAC Fallback Enabled: ${hmacFallbackEnabled}")
+            if (hmacFallbackEnabled) {
+                return Algorithm.HMAC256(Base64.getDecoder().decode(jwtSecret))
+            }
         }
         throw UnknownTokenException("No enabled algorithm for platform token validation")
     }
@@ -81,6 +80,8 @@ class DualJwtValidator @Inject constructor(
         try {
             val decoded = JWT.decode(token)
             val issuer = decoded.issuer
+
+            log.info("Token issuer: $issuer")
 
             return when {
                 issuer == "$baseApiUrl$supabaseAuthPath" -> TokenSource.SUPABASE

--- a/src/test/kotlin/org/incept5/platform/core/security/DualJwtValidatorTest.kt
+++ b/src/test/kotlin/org/incept5/platform/core/security/DualJwtValidatorTest.kt
@@ -139,7 +139,16 @@ class DualJwtValidatorTest {
         )
 
         // When
-        val result = dualJwtValidator.validateToken(token)
+        val v = DualJwtValidator(
+            jwtSecret = jwtSecret,
+            baseApiUrl = baseApiUrl,
+            supabaseAuthPath = supabaseAuthPath,
+            platformOauthPath = platformOauthPath,
+            rsaEnabled = false,
+            rsaPrivateKey = "",
+            hmacFallbackEnabled = true
+        )
+        val result = v.validateToken(token)
 
         // Then
         result.isValid shouldBe true
@@ -163,7 +172,16 @@ class DualJwtValidatorTest {
         )
 
         // When
-        val result = dualJwtValidator.validateToken(token)
+        val v = DualJwtValidator(
+            jwtSecret = jwtSecret,
+            baseApiUrl = baseApiUrl,
+            supabaseAuthPath = supabaseAuthPath,
+            platformOauthPath = platformOauthPath,
+            rsaEnabled = false,
+            rsaPrivateKey = "",
+            hmacFallbackEnabled = true
+        )
+        val result = v.validateToken(token)
 
         // Then
         result.isValid shouldBe true
@@ -319,7 +337,16 @@ class DualJwtValidatorTest {
         )
 
         // When
-        val entityType = dualJwtValidator.getEntityType(token)
+        val v = DualJwtValidator(
+            jwtSecret = jwtSecret,
+            baseApiUrl = baseApiUrl,
+            supabaseAuthPath = supabaseAuthPath,
+            platformOauthPath = platformOauthPath,
+            rsaEnabled = false,
+            rsaPrivateKey = "",
+            hmacFallbackEnabled = true
+        )
+        val entityType = v.getEntityType(token)
 
         // Then
         entityType shouldBe null
@@ -399,7 +426,7 @@ class DualJwtValidatorTest {
             baseApiUrl = baseApiUrl,
             rsaEnabled = true,
             rsaPrivateKey = privateKeyBase64,
-            supabaseJwtEnabled = false
+            hmacFallbackEnabled = false
         )
 
         // RS256-signed platform token
@@ -419,5 +446,58 @@ class DualJwtValidatorTest {
         result.subject shouldBe "client-rs256"
         result.userRole shouldBe UserRole.entity_admin
         result.clientId shouldBe "client-rs256"
+    }
+
+    @Test
+    fun `should validate HS256 Platform token when HMAC fallback enabled`() {
+        val v = DualJwtValidator(
+            jwtSecret = jwtSecret,
+            baseApiUrl = baseApiUrl,
+            supabaseAuthPath = supabaseAuthPath,
+            platformOauthPath = platformOauthPath,
+            rsaEnabled = false,
+            rsaPrivateKey = "",
+            hmacFallbackEnabled = true
+        )
+
+        val token = JWT.create()
+            .withSubject("client-hs256")
+            .withIssuer("$baseApiUrl$platformOauthPath")
+            .withClaim("role", UserRole.entity_admin.name)
+            .withClaim("scopes", listOf("payment:read"))
+            .withExpiresAt(Date.from(Instant.now().plusSeconds(3600)))
+            .sign(algorithm)
+
+        val result = v.validateToken(token)
+        result.isValid shouldBe true
+        result.subject shouldBe "client-hs256"
+        result.userRole shouldBe UserRole.entity_admin
+        result.clientId shouldBe "client-hs256"
+    }
+
+    @Test
+    fun `should fail HS256 Platform token when HMAC fallback disabled`() {
+        val v = DualJwtValidator(
+            jwtSecret = jwtSecret,
+            baseApiUrl = baseApiUrl,
+            supabaseAuthPath = supabaseAuthPath,
+            platformOauthPath = platformOauthPath,
+            rsaEnabled = false,
+            rsaPrivateKey = "",
+            hmacFallbackEnabled = false
+        )
+
+        val token = JWT.create()
+            .withSubject("client-hs256-no-fallback")
+            .withIssuer("$baseApiUrl$platformOauthPath")
+            .withClaim("role", UserRole.entity_admin.name)
+            .withClaim("scopes", listOf("payment:read"))
+            .withExpiresAt(Date.from(Instant.now().plusSeconds(3600)))
+            .sign(algorithm)
+
+        val ex = shouldThrow<UnknownTokenException> {
+            v.validateToken(token)
+        }
+        ex.message?.contains("No enabled algorithm for platform token validation") shouldBe true
     }
 }

--- a/src/test/kotlin/org/incept5/platform/core/security/DualJwtValidatorTest.kt
+++ b/src/test/kotlin/org/incept5/platform/core/security/DualJwtValidatorTest.kt
@@ -139,7 +139,7 @@ class DualJwtValidatorTest {
         )
 
         // When
-        val v = DualJwtValidator(
+        val validator = DualJwtValidator(
             jwtSecret = jwtSecret,
             baseApiUrl = baseApiUrl,
             supabaseAuthPath = supabaseAuthPath,
@@ -148,7 +148,7 @@ class DualJwtValidatorTest {
             rsaPrivateKey = "",
             hmacFallbackEnabled = true
         )
-        val result = v.validateToken(token)
+        val result = validator.validateToken(token)
 
         // Then
         result.isValid shouldBe true
@@ -172,7 +172,7 @@ class DualJwtValidatorTest {
         )
 
         // When
-        val v = DualJwtValidator(
+        val validator = DualJwtValidator(
             jwtSecret = jwtSecret,
             baseApiUrl = baseApiUrl,
             supabaseAuthPath = supabaseAuthPath,
@@ -181,7 +181,7 @@ class DualJwtValidatorTest {
             rsaPrivateKey = "",
             hmacFallbackEnabled = true
         )
-        val result = v.validateToken(token)
+        val result = validator.validateToken(token)
 
         // Then
         result.isValid shouldBe true
@@ -337,7 +337,7 @@ class DualJwtValidatorTest {
         )
 
         // When
-        val v = DualJwtValidator(
+        val validator = DualJwtValidator(
             jwtSecret = jwtSecret,
             baseApiUrl = baseApiUrl,
             supabaseAuthPath = supabaseAuthPath,
@@ -346,7 +346,7 @@ class DualJwtValidatorTest {
             rsaPrivateKey = "",
             hmacFallbackEnabled = true
         )
-        val entityType = v.getEntityType(token)
+        val entityType = validator.getEntityType(token)
 
         // Then
         entityType shouldBe null
@@ -450,7 +450,7 @@ class DualJwtValidatorTest {
 
     @Test
     fun `should validate HS256 Platform token when HMAC fallback enabled`() {
-        val v = DualJwtValidator(
+        val validator = DualJwtValidator(
             jwtSecret = jwtSecret,
             baseApiUrl = baseApiUrl,
             supabaseAuthPath = supabaseAuthPath,
@@ -468,7 +468,7 @@ class DualJwtValidatorTest {
             .withExpiresAt(Date.from(Instant.now().plusSeconds(3600)))
             .sign(algorithm)
 
-        val result = v.validateToken(token)
+        val result = validator.validateToken(token)
         result.isValid shouldBe true
         result.subject shouldBe "client-hs256"
         result.userRole shouldBe UserRole.entity_admin
@@ -477,7 +477,7 @@ class DualJwtValidatorTest {
 
     @Test
     fun `should fail HS256 Platform token when HMAC fallback disabled`() {
-        val v = DualJwtValidator(
+        val validator = DualJwtValidator(
             jwtSecret = jwtSecret,
             baseApiUrl = baseApiUrl,
             supabaseAuthPath = supabaseAuthPath,
@@ -496,7 +496,7 @@ class DualJwtValidatorTest {
             .sign(algorithm)
 
         val ex = shouldThrow<UnknownTokenException> {
-            v.validateToken(token)
+            validator.validateToken(token)
         }
         ex.message?.contains("No enabled algorithm for platform token validation") shouldBe true
     }


### PR DESCRIPTION
…back flag

- Rename configuration property from supabase.jwt.enabled to rsa-jwt.hmac-fallback.enabled
- Update logic to use hmacFallbackEnabled flag for HMAC algorithm fallback
- Add logging for token issuer and fallback status
- Update tests to reflect new configuration flag