### PR TITLE
FF-1850: Integrate authz-lib into platform-core-lib

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,8 @@ dependencies {
     // Incept5 external dependencies
     api(libs.incept5.correlation)
     api(libs.incept5.error.quarkus)
+    api(libs.incept5.authz.core)
+    api(libs.incept5.authz.quarkus)
 
     // JSON processing
     api("com.fasterxml.jackson.core:jackson-databind")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ java-jwt = "4.4.0"
 correlation = "1.0.20"
 error-lib = "1.0.26"
 cryptography-lib = "1.0.28"
-authz-lib = "1.0.6"
+authz-lib = "1.0.12"
 
 [libraries]
 # Core dependencies

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ java-jwt = "4.4.0"
 correlation = "1.0.20"
 error-lib = "1.0.26"
 cryptography-lib = "1.0.28"
+authz-lib = "1.0.6"
 
 [libraries]
 # Core dependencies
@@ -40,6 +41,9 @@ wiremock = { module = "org.wiremock:wiremock", version.ref = "wiremock" }
 incept5-correlation = { module = "com.github.incept5:correlation", version.ref = "correlation" }
 incept5-error-quarkus = { module = "com.github.incept5.error-lib:error-quarkus", version.ref = "error-lib" }
 incept5-cryptography = { module = "com.github.incept5.cryptography-lib:cryptography-quarkus", version.ref = "cryptography-lib" }
+incept5-authz-core = { module = "com.github.incept5.authz-lib:authz-core", version.ref = "authz-lib" }
+incept5-authz-quarkus = { module = "com.github.incept5.authz-lib:authz-quarkus", version.ref = "authz-lib" }
+incept5-authz-testing = { module = "com.github.incept5.authz-lib:authz-testing", version.ref = "authz-lib" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ java-jwt = "4.4.0"
 correlation = "1.0.20"
 error-lib = "1.0.26"
 cryptography-lib = "1.0.28"
-authz-lib = "1.0.12"
+authz-lib = "1.0.15"
 
 [libraries]
 # Core dependencies

--- a/src/main/kotlin/org/incept5/platform/core/authz/SupabaseTokenExchangePlugin.kt
+++ b/src/main/kotlin/org/incept5/platform/core/authz/SupabaseTokenExchangePlugin.kt
@@ -1,0 +1,94 @@
+package org.incept5.platform.core.authz
+
+import jakarta.inject.Singleton
+import org.incept5.authz.core.context.DefaultPrincipalContext
+import org.incept5.authz.core.context.PrincipalContext
+import org.incept5.authz.core.model.EntityRole
+import org.incept5.authz.core.service.TokenExchangePlugin
+import org.incept5.platform.core.model.EntityType
+import org.incept5.platform.core.model.UserRole
+import org.incept5.platform.core.security.DualJwtValidator
+import org.incept5.platform.core.security.TokenValidationResult
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * Bridges the existing DualJwtValidator to authz-lib's PrincipalContext model.
+ *
+ * Validates the incoming JWT token using the existing validator and maps the
+ * result to a PrincipalContext with appropriate global roles and entity roles.
+ */
+@Singleton
+class SupabaseTokenExchangePlugin(
+    private val dualJwtValidator: DualJwtValidator
+) : TokenExchangePlugin {
+
+    private val log = Logger.getLogger(SupabaseTokenExchangePlugin::class.java)
+
+    override fun exchangeToken(token: String): PrincipalContext? {
+        val result = try {
+            dualJwtValidator.validateToken(token)
+        } catch (e: Exception) {
+            log.debug("Token validation failed: ${e.message}")
+            return null
+        }
+
+        val principalId = try {
+            UUID.fromString(result.subject)
+        } catch (e: IllegalArgumentException) {
+            // Some tokens (e.g., service_role) may not have a UUID subject.
+            // Generate a deterministic UUID from the subject string.
+            UUID.nameUUIDFromBytes(result.subject.toByteArray())
+        }
+
+        val globalRole = mapRole(result.userRole, result.entityType)
+        val entityRoles = buildEntityRoles(result)
+
+        log.debug("Token exchanged: subject=${result.subject}, globalRole=$globalRole, entityRoles=$entityRoles")
+
+        return DefaultPrincipalContext(
+            principalId = principalId,
+            globalRoles = listOf(globalRole),
+            entityRoles = entityRoles
+        )
+    }
+
+    /**
+     * Maps the existing UserRole + EntityType combination to an authz-lib role name.
+     */
+    internal fun mapRole(userRole: UserRole, entityType: EntityType?): String = when (userRole) {
+        UserRole.platform_admin, UserRole.service_role -> "backoffice.admin"
+        UserRole.entity_admin -> when (entityType) {
+            EntityType.partner -> "partner.admin"
+            EntityType.merchant -> "merchant.admin"
+            else -> "partner.user"
+        }
+        UserRole.entity_user -> when (entityType) {
+            EntityType.partner -> "partner.user"
+            EntityType.merchant -> "merchant.user"
+            else -> "partner.user"
+        }
+        UserRole.entity_readonly -> when (entityType) {
+            EntityType.partner -> "partner.user"
+            EntityType.merchant -> "merchant.user"
+            else -> "partner.user"
+        }
+    }
+
+    /**
+     * Builds entity-scoped roles from the token validation result.
+     * Only created when both entityType and entityId are present.
+     */
+    private fun buildEntityRoles(result: TokenValidationResult): List<EntityRole> {
+        if (result.entityType == null || result.entityId == null) return emptyList()
+
+        val roleName = mapRole(result.userRole, result.entityType)
+        return listOf(
+            EntityRole(
+                type = result.entityType!!.name.lowercase(),
+                roles = listOf(roleName),
+                ids = listOf(result.entityId!!)
+            )
+        )
+    }
+}

--- a/src/test/kotlin/org/incept5/platform/core/authz/SupabaseTokenExchangePluginTest.kt
+++ b/src/test/kotlin/org/incept5/platform/core/authz/SupabaseTokenExchangePluginTest.kt
@@ -1,0 +1,357 @@
+package org.incept5.platform.core.authz
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.incept5.platform.core.model.EntityType
+import org.incept5.platform.core.model.UserRole
+import org.incept5.platform.core.security.DualJwtValidator
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.*
+
+class SupabaseTokenExchangePluginTest {
+
+    private lateinit var plugin: SupabaseTokenExchangePlugin
+    private lateinit var dualJwtValidator: DualJwtValidator
+
+    private val jwtSecretBytes = "test-secret-key-that-is-long-enough-for-hmac256-algorithm".toByteArray()
+    private val jwtSecret = Base64.getEncoder().encodeToString(jwtSecretBytes)
+    private val baseApiUrl = "https://api.test.com"
+    private val supabaseAuthPath = "/auth/v1"
+    private val platformOauthPath = "/api/v1/oauth/token"
+    private val algorithm = Algorithm.HMAC256(jwtSecretBytes)
+
+    @BeforeEach
+    fun setup() {
+        dualJwtValidator = DualJwtValidator(
+            jwtSecret = jwtSecret,
+            hmacFallbackEnabled = true,
+            baseApiUrl = baseApiUrl,
+            supabaseAuthPath = supabaseAuthPath,
+            platformOauthPath = platformOauthPath,
+            rsaPublicKey = Optional.empty(),
+            jwksUrl = Optional.empty()
+        )
+        plugin = SupabaseTokenExchangePlugin(dualJwtValidator)
+    }
+
+    // AC4: Platform admin maps to backoffice.admin
+    @Test
+    fun `platform_admin maps to backoffice admin with no entity roles`() {
+        val subject = UUID.randomUUID().toString()
+        val token = createSupabaseToken(subject, UserRole.platform_admin)
+
+        val result = plugin.exchangeToken(token)
+
+        result.shouldNotBeNull()
+        result.getPrincipalId() shouldBe UUID.fromString(subject)
+        result.getGlobalRoles().shouldContainExactly("backoffice.admin")
+        result.getEntityRoles().shouldBeEmpty()
+    }
+
+    // AC5: Service role maps to backoffice.admin
+    @Test
+    fun `service_role maps to backoffice admin with no entity roles`() {
+        val token = createSupabaseToken(
+            subject = UUID.randomUUID().toString(),
+            role = UserRole.service_role
+        )
+
+        val result = plugin.exchangeToken(token)
+
+        result.shouldNotBeNull()
+        result.getGlobalRoles().shouldContainExactly("backoffice.admin")
+        result.getEntityRoles().shouldBeEmpty()
+    }
+
+    // AC2: entity_admin + partner maps to partner.admin
+    @Test
+    fun `entity_admin with partner maps to partner admin with entity role`() {
+        val subject = UUID.randomUUID().toString()
+        val partnerId = "P1"
+        val token = createSupabaseToken(
+            subject = subject,
+            role = UserRole.entity_admin,
+            entityType = EntityType.partner,
+            entityId = partnerId
+        )
+
+        val result = plugin.exchangeToken(token)
+
+        result.shouldNotBeNull()
+        result.getPrincipalId() shouldBe UUID.fromString(subject)
+        result.getGlobalRoles().shouldContainExactly("partner.admin")
+        result.getEntityRoles().shouldHaveSize(1)
+        result.getEntityRoles()[0].let { entityRole ->
+            entityRole.type shouldBe "partner"
+            entityRole.roles.shouldContainExactly("partner.admin")
+            entityRole.ids.shouldContainExactly(partnerId)
+        }
+    }
+
+    // AC2 variant: entity_admin + merchant maps to merchant.admin
+    @Test
+    fun `entity_admin with merchant maps to merchant admin with entity role`() {
+        val subject = UUID.randomUUID().toString()
+        val merchantId = "M1"
+        val token = createSupabaseToken(
+            subject = subject,
+            role = UserRole.entity_admin,
+            entityType = EntityType.merchant,
+            entityId = merchantId
+        )
+
+        val result = plugin.exchangeToken(token)
+
+        result.shouldNotBeNull()
+        result.getGlobalRoles().shouldContainExactly("merchant.admin")
+        result.getEntityRoles().shouldHaveSize(1)
+        result.getEntityRoles()[0].let { entityRole ->
+            entityRole.type shouldBe "merchant"
+            entityRole.roles.shouldContainExactly("merchant.admin")
+            entityRole.ids.shouldContainExactly(merchantId)
+        }
+    }
+
+    // AC3: entity_user + partner maps to partner.user
+    @Test
+    fun `entity_user with partner maps to partner user with entity role`() {
+        val subject = UUID.randomUUID().toString()
+        val partnerId = "P1"
+        val token = createSupabaseToken(
+            subject = subject,
+            role = UserRole.entity_user,
+            entityType = EntityType.partner,
+            entityId = partnerId
+        )
+
+        val result = plugin.exchangeToken(token)
+
+        result.shouldNotBeNull()
+        result.getGlobalRoles().shouldContainExactly("partner.user")
+        result.getEntityRoles().shouldHaveSize(1)
+        result.getEntityRoles()[0].let { entityRole ->
+            entityRole.type shouldBe "partner"
+            entityRole.roles.shouldContainExactly("partner.user")
+            entityRole.ids.shouldContainExactly(partnerId)
+        }
+    }
+
+    // AC3: entity_user + merchant maps to merchant.user
+    @Test
+    fun `entity_user with merchant maps to merchant user with entity role`() {
+        val subject = UUID.randomUUID().toString()
+        val merchantId = "M1"
+        val token = createSupabaseToken(
+            subject = subject,
+            role = UserRole.entity_user,
+            entityType = EntityType.merchant,
+            entityId = merchantId
+        )
+
+        val result = plugin.exchangeToken(token)
+
+        result.shouldNotBeNull()
+        result.getGlobalRoles().shouldContainExactly("merchant.user")
+        result.getEntityRoles().shouldHaveSize(1)
+        result.getEntityRoles()[0].let { entityRole ->
+            entityRole.type shouldBe "merchant"
+            entityRole.roles.shouldContainExactly("merchant.user")
+            entityRole.ids.shouldContainExactly(merchantId)
+        }
+    }
+
+    // entity_readonly maps to user role (readonly differentiation via permissions, not roles)
+    @Test
+    fun `entity_readonly with partner maps to partner user with entity role`() {
+        val subject = UUID.randomUUID().toString()
+        val partnerId = "P1"
+        val token = createSupabaseToken(
+            subject = subject,
+            role = UserRole.entity_readonly,
+            entityType = EntityType.partner,
+            entityId = partnerId
+        )
+
+        val result = plugin.exchangeToken(token)
+
+        result.shouldNotBeNull()
+        result.getGlobalRoles().shouldContainExactly("partner.user")
+        result.getEntityRoles().shouldHaveSize(1)
+        result.getEntityRoles()[0].let { entityRole ->
+            entityRole.type shouldBe "partner"
+            entityRole.roles.shouldContainExactly("partner.user")
+            entityRole.ids.shouldContainExactly(partnerId)
+        }
+    }
+
+    @Test
+    fun `entity_readonly with merchant maps to merchant user with entity role`() {
+        val subject = UUID.randomUUID().toString()
+        val merchantId = "M1"
+        val token = createSupabaseToken(
+            subject = subject,
+            role = UserRole.entity_readonly,
+            entityType = EntityType.merchant,
+            entityId = merchantId
+        )
+
+        val result = plugin.exchangeToken(token)
+
+        result.shouldNotBeNull()
+        result.getGlobalRoles().shouldContainExactly("merchant.user")
+        result.getEntityRoles().shouldHaveSize(1)
+        result.getEntityRoles()[0].let { entityRole ->
+            entityRole.type shouldBe "merchant"
+            entityRole.roles.shouldContainExactly("merchant.user")
+            entityRole.ids.shouldContainExactly(merchantId)
+        }
+    }
+
+    // AC6: Invalid token returns null
+    @Test
+    fun `invalid token returns null`() {
+        val result = plugin.exchangeToken("invalid.token.here")
+
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `expired token returns null`() {
+        val token = JWT.create()
+            .withSubject(UUID.randomUUID().toString())
+            .withClaim("role", UserRole.platform_admin.name)
+            .withIssuer("$baseApiUrl$supabaseAuthPath")
+            .withExpiresAt(Instant.now().minusSeconds(3600))
+            .sign(algorithm)
+
+        val result = plugin.exchangeToken(token)
+
+        result.shouldBeNull()
+    }
+
+    // AC9: entity_admin with null entityType has no entity roles
+    @Test
+    fun `entity_admin with null entityType has global role but no entity roles`() {
+        val subject = UUID.randomUUID().toString()
+        val token = createSupabaseToken(
+            subject = subject,
+            role = UserRole.entity_admin
+        )
+
+        val result = plugin.exchangeToken(token)
+
+        result.shouldNotBeNull()
+        result.getGlobalRoles().shouldContainExactly("partner.user")
+        result.getEntityRoles().shouldBeEmpty()
+    }
+
+    // AC10: Platform token (client credentials) maps correctly
+    @Test
+    fun `platform token with entity_admin role maps correctly`() {
+        val subject = UUID.randomUUID().toString()
+        val partnerId = "P1"
+        val token = createPlatformToken(
+            subject = subject,
+            role = UserRole.entity_admin,
+            entityType = EntityType.partner,
+            entityId = partnerId
+        )
+
+        val result = plugin.exchangeToken(token)
+
+        result.shouldNotBeNull()
+        result.getPrincipalId() shouldBe UUID.fromString(subject)
+        result.getGlobalRoles().shouldContainExactly("partner.admin")
+        result.getEntityRoles().shouldHaveSize(1)
+        result.getEntityRoles()[0].let { entityRole ->
+            entityRole.type shouldBe "partner"
+            entityRole.roles.shouldContainExactly("partner.admin")
+            entityRole.ids.shouldContainExactly(partnerId)
+        }
+    }
+
+    // --- Role mapping unit tests (using internal method) ---
+
+    @Test
+    fun `mapRole covers all UserRole and EntityType combinations`() {
+        // Platform-level roles
+        plugin.mapRole(UserRole.platform_admin, null) shouldBe "backoffice.admin"
+        plugin.mapRole(UserRole.service_role, null) shouldBe "backoffice.admin"
+
+        // Partner entity roles
+        plugin.mapRole(UserRole.entity_admin, EntityType.partner) shouldBe "partner.admin"
+        plugin.mapRole(UserRole.entity_user, EntityType.partner) shouldBe "partner.user"
+        plugin.mapRole(UserRole.entity_readonly, EntityType.partner) shouldBe "partner.user"
+
+        // Merchant entity roles
+        plugin.mapRole(UserRole.entity_admin, EntityType.merchant) shouldBe "merchant.admin"
+        plugin.mapRole(UserRole.entity_user, EntityType.merchant) shouldBe "merchant.user"
+        plugin.mapRole(UserRole.entity_readonly, EntityType.merchant) shouldBe "merchant.user"
+
+        // Fallback for null entity type on entity roles
+        plugin.mapRole(UserRole.entity_admin, null) shouldBe "partner.user"
+        plugin.mapRole(UserRole.entity_user, null) shouldBe "partner.user"
+        plugin.mapRole(UserRole.entity_readonly, null) shouldBe "partner.user"
+    }
+
+    // --- Helper methods ---
+
+    private fun createSupabaseToken(
+        subject: String,
+        role: UserRole,
+        entityType: EntityType? = null,
+        entityId: String? = null
+    ): String {
+        val builder = JWT.create()
+            .withSubject(subject)
+            .withClaim("role", role.name)
+            .withIssuer("$baseApiUrl$supabaseAuthPath")
+            .withIssuedAt(Instant.now())
+            .withExpiresAt(Instant.now().plusSeconds(3600))
+
+        if (entityType != null || entityId != null) {
+            val appMetadata = mutableMapOf<String, Any>()
+            entityType?.let { appMetadata["entity_type"] = it.name }
+            entityId?.let { appMetadata["entity_id"] = it }
+            builder.withClaim("app_metadata", appMetadata)
+        }
+
+        return builder.sign(algorithm)
+    }
+
+    private fun createPlatformToken(
+        subject: String,
+        role: UserRole,
+        entityType: EntityType? = null,
+        entityId: String? = null,
+        scopes: List<String> = emptyList()
+    ): String {
+        val builder = JWT.create()
+            .withSubject(subject)
+            .withClaim("role", role.name)
+            .withIssuer("$baseApiUrl$platformOauthPath")
+            .withIssuedAt(Instant.now())
+            .withExpiresAt(Instant.now().plusSeconds(3600))
+
+        if (scopes.isNotEmpty()) {
+            builder.withClaim("scopes", scopes)
+        }
+
+        if (entityType != null || entityId != null) {
+            val appMetadata = mutableMapOf<String, Any>()
+            entityType?.let { appMetadata["entity_type"] = it.name }
+            entityId?.let { appMetadata["entity_id"] = it }
+            builder.withClaim("app_metadata", appMetadata)
+        }
+
+        return builder.sign(algorithm)
+    }
+}


### PR DESCRIPTION
Add authz-lib (core + quarkus) dependencies and implement SupabaseTokenExchangePlugin that bridges DualJwtValidator to authz-lib's PrincipalContext model. Maps existing roles to new fine-grained roles (platform_admin → backoffice.admin, entity_admin+partner → partner.admin, etc.) and builds entity-scoped EntityRole entries from JWT claims.

Runs alongside existing AuthenticationFilter and
ScopeAuthorizationFilter — no breaking changes.