### PR TITLE
Map RateLimitExceededException to HTTP 429 via error-lib 1.0.50

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,28 @@ fun submitContact(form: ContactForm): Response {
 }
 ```
 
+When the limit is exceeded the interceptor throws `RateLimitExceededException`,
+which error-lib's `RestErrorHandler` maps to an HTTP 429 (Too Many Requests)
+response with a `Retry-After` header (in seconds) and the standard error body:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Rate limit exceeded. Maximum 10 requests per minute allowed.",
+      "code": "RATE_LIMIT_EXCEEDED"
+    }
+  ],
+  "correlationId": "unique-correlation-id",
+  "httpStatusCode": 429
+}
+```
+
+No custom `ExceptionMapper` is needed in consuming services — services that
+registered their own mapper for `RateLimitExceededException` can delete it.
+The interceptor WARN-logs each rejection with the bucket key and limit;
+error-lib logs the 429 mapping at DEBUG to avoid double-logging.
+
 ## ULID Generation
 
 Inject `UlidService` for time-sortable unique ID generation:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "2.1.0"
-quarkus = "3.22.2"
+kotlin = "2.3.10"
+quarkus = "3.34.3"
 logbook = "3.10.0"
 mockito-kotlin = "5.2.1"
 kotest = "5.8.0"
@@ -12,9 +12,9 @@ java-jwt = "4.4.0"
 
 # Incept5 Libraries
 correlation = "1.0.20"
-error-lib = "1.0.26"
+error-lib = "1.0.50"
 cryptography-lib = "1.0.28"
-authz-lib = "1.0.27"
+authz-lib = "1.0.29"
 
 [libraries]
 # Core dependencies

--- a/src/main/kotlin/org/incept5/platform/core/ratelimit/exception/RateLimitExceededException.kt
+++ b/src/main/kotlin/org/incept5/platform/core/ratelimit/exception/RateLimitExceededException.kt
@@ -1,14 +1,14 @@
 package org.incept5.platform.core.ratelimit.exception
 
-import org.incept5.platform.core.error.ApiException
-import org.incept5.error.ErrorCategory
+import org.incept5.error.RateLimitExceededException as CoreRateLimitExceededException
 
 /**
  * Exception thrown when rate limit is exceeded.
- * Maps to HTTP 429 Too Many Requests status code.
+ * Maps to HTTP 429 Too Many Requests with a Retry-After header set from
+ * retryAfterSeconds (defaulting to 60) via error-lib's RestErrorHandler.
  */
 class RateLimitExceededException(
     message: String = "Rate limit exceeded",
     val requestsPerMinute: Int? = null,
-    val retryAfterSeconds: Long? = null
-) : ApiException(message, ErrorCategory.CONFLICT)
+    retryAfterSeconds: Long? = null
+) : CoreRateLimitExceededException(message, retryAfterSeconds)

--- a/src/test/kotlin/org/incept5/platform/core/ratelimit/exception/RateLimitExceededExceptionTest.kt
+++ b/src/test/kotlin/org/incept5/platform/core/ratelimit/exception/RateLimitExceededExceptionTest.kt
@@ -1,0 +1,33 @@
+package org.incept5.platform.core.ratelimit.exception
+
+import org.assertj.core.api.Assertions.assertThat
+import org.incept5.error.ErrorCategory
+import org.junit.jupiter.api.Test
+
+class RateLimitExceededExceptionTest {
+
+    @Test
+    fun `should carry RATE_LIMIT_EXCEEDED category so error-lib maps it to 429`() {
+        val exception = RateLimitExceededException(
+            message = "Rate limit exceeded. Maximum 10 requests per minute allowed.",
+            requestsPerMinute = 10,
+            retryAfterSeconds = 60
+        )
+
+        assertThat(exception.category).isEqualTo(ErrorCategory.RATE_LIMIT_EXCEEDED)
+        assertThat(exception.errors).hasSize(1)
+        assertThat(exception.errors[0].code).isEqualTo("RATE_LIMIT_EXCEEDED")
+        assertThat(exception.retryable).isTrue()
+        assertThat(exception.retryAfterSeconds).isEqualTo(60)
+        assertThat(exception.requestsPerMinute).isEqualTo(10)
+    }
+
+    @Test
+    fun `should default message and leave retryAfterSeconds null when not supplied`() {
+        val exception = RateLimitExceededException()
+
+        assertThat(exception.message).isEqualTo("Rate limit exceeded")
+        assertThat(exception.retryAfterSeconds).isNull()
+        assertThat(exception.requestsPerMinute).isNull()
+    }
+}


### PR DESCRIPTION
Re-parent RateLimitExceededException from ApiException with the CONFLICT category (which error-lib mapped to 409) onto error-lib's new RateLimitExceededException, so the standard RestErrorHandler returns HTTP 429 (Too Many Requests) with a Retry-After header set from retryAfterSeconds. The exception is now also retryable.

Consuming services no longer need a custom ExceptionMapper to translate rate limit rejections into 429 responses and can delete theirs.

Bump error-lib to 1.0.50 (which introduced the RATE_LIMIT_EXCEEDED category) and document the 429 response shape in the README.